### PR TITLE
Use correct version for GCC 8.4.0 in ESP32S3 config

### DIFF
--- a/samples/xtensa-esp32s3-elf/crosstool.config
+++ b/samples/xtensa-esp32s3-elf/crosstool.config
@@ -47,8 +47,8 @@ CT_LIBC_NEWLIB_AUX_BUILD_TARGET_CFLAGS=""
 
 # For compatibility with GCC 8, change it when update
 CT_ISL_V_0_19=y
-CT_GCC_V_8_5_0=y
-CT_GCC_VERSION="8.5.0"
+CT_GCC_V_8_4_0=y
+CT_GCC_VERSION="8.4.0"
 CT_GCC_SRC_DEVEL=y
 CT_GCC_DEVEL_VCS_git=y
 CT_GCC_DEVEL_VCS="git"


### PR DESCRIPTION
I am not entirely sure, if this really was the fix for my problems with lib-builder for Arduino, but at least this is closer to the truth.

Would have to be changed for the rest of the ESP32 family too.